### PR TITLE
Fix parseInt radix issue in tic tac toe

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,7 +15,8 @@ const restartButton = document.getElementById('restartButton');
 
 function handleCellClick(clickedCellEvent) {
     const clickedCell = clickedCellEvent.target;
-    const clickedCellIndex = parseInt(clickedCell.getAttribute('data-cell-index'));
+    // Explicitly specify base 10 to avoid unexpected parsing in older browsers
+    const clickedCellIndex = parseInt(clickedCell.getAttribute('data-cell-index'), 10);
 
     if (gameState.board[clickedCellIndex] !== '' || !gameState.gameActive) {
         return;


### PR DESCRIPTION
## Summary
- avoid legacy parseInt behavior by providing radix when reading data attribute

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68412f528eec8321b459bba6e49f1940